### PR TITLE
Use public ECR instead of dockerhub image

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ runs:
         path: ${{ steps.destination_dir.outputs.name }}
 
     - name: Read platform context
-      uses: docker://segment/chamber:2.11.0
+      uses: docker://public.ecr.aws/u3q6g8t1/chamber:2.10.12
       if: ${{ inputs.operation == 'deploy' }}
       with:
         args: --verbose export ${{ inputs.ssm-path }}/${{ inputs.environment }} --format yaml --output-file ./platform.yaml
@@ -135,7 +135,7 @@ runs:
         yq --exit-status --no-colors --inplace eval '{"platform": .}' ./platform.yaml
 
     - name: Read platform metadata
-      uses: docker://segment/chamber:2.11.0
+      uses: docker://public.ecr.aws/u3q6g8t1/chamber:2.10.12
       if: ${{ inputs.operation == 'deploy' }}
       with:
         args: --verbose export ${{ inputs.ssm-path }}/_metadata --format yaml --output-file ./_metadata.yaml


### PR DESCRIPTION
## what
* Use `public.ecr.aws/u3q6g8t1/chamber:2.10.12` instead of dockerhub image

## why
* dockerhub has low limits