### PR TITLE
chore(DEV-1396): Replace `git-url-parse` action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,7 @@ runs:
       with:
         script: |
           const GitUrlParse = require("git-url-parse");
-          async function run(url) {
+          function run(url) {
             try { 
               console.log("url: %s", url)
               const urlObj = GitUrlParse(url);

--- a/action.yml
+++ b/action.yml
@@ -103,11 +103,37 @@ runs:
         helm-version: v3.10.2
         install-kubectl: false
 
-    - name: Parse git URL for 
+    #- name: Parse git URL for 
+    #  id: destination
+    #  uses: theowenyoung/git-url-parse@v1
+    #  with:
+    #    url: ${{ inputs.cluster }}
+
+    - run: npm install git-url-parse
+    - name: Parse git URL for destination
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1, node20
       id: destination
-      uses: theowenyoung/git-url-parse@v1
       with:
-        url: ${{ inputs.cluster }}
+        result-encoding: string
+        script: |
+          const GitUrlParse = require("git-url-parse");
+          async function run(url) {
+            try { 
+              console.log("url: %s", url)
+              const urlObj = GitUrlParse(url);
+              core.setOutput('result', JSON.stringify(urlObj));
+              const keys = Object.keys(urlObj);
+              keys.forEach(key=>{
+                if(typeof urlObj[key] === 'string' || urlObj[key] === null){
+                  core.setOutput(key, urlObj[key]);
+                }
+              })
+            } 
+            catch (error) {
+              core.setFailed(error.message);
+            }
+          }
+          run(${{ inputs.cluster }})
 
     - name: echo output for debugging
       shell: bash
@@ -117,6 +143,12 @@ runs:
         echo "name: ${{ steps.destination.outputs.name }}"
         echo "ref: ${{ steps.destination.outputs.ref }}"
         echo "owner: ${{ steps.destination.outputs.owner }}"
+
+    #"cluster: https://github.com/cloudposse/argocd-deploy-non-prod/blob/main/plat/ue2-dev/apps"
+    #"filepath: plat/ue2-dev/apps"
+    #"name: argocd-deploy-non-prod"
+    #"ref: main"
+    #"owner: cloudposse"
 
     - id: destination_dir
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -108,7 +108,7 @@ runs:
       run: npm install git-url-parse
 
     - name: Parse git URL for destination
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1, node 20
+      uses: actions/github-script@v7
       id: destination
       with:
         script: |

--- a/action.yml
+++ b/action.yml
@@ -144,6 +144,8 @@ runs:
         echo "ref: ${{ steps.destination.outputs.ref }}"
         echo "owner: ${{ steps.destination.outputs.owner }}"
 
+        exit 1
+
     #"cluster: https://github.com/cloudposse/argocd-deploy-non-prod/blob/main/plat/ue2-dev/apps"
     #"filepath: plat/ue2-dev/apps"
     #"name: argocd-deploy-non-prod"

--- a/action.yml
+++ b/action.yml
@@ -117,7 +117,6 @@ runs:
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1, node20
       id: destination
       with:
-        result-encoding: string
         script: |
           const GitUrlParse = require("git-url-parse");
           async function run(url) {
@@ -136,7 +135,7 @@ runs:
               core.setFailed(error.message);
             }
           }
-          run(${{ inputs.cluster }})
+          run("${{ inputs.cluster }}")
 
     - name: echo output for debugging
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -103,10 +103,20 @@ runs:
         helm-version: v3.10.2
         install-kubectl: false
 
-    - id: destination
+    - name: Parse git URL for 
+      id: destination
       uses: theowenyoung/git-url-parse@v1
       with:
         url: ${{ inputs.cluster }}
+
+    - name: echo output for debugging
+      shell: bash
+      run: |
+        echo "cluster: ${{ inputs.cluster }}"
+        echo "filepath: ${{ steps.destination.outputs.filepath }}"
+        echo "name: ${{ steps.destination.outputs.name }}"
+        echo "ref: ${{ steps.destination.outputs.ref }}"
+        echo "owner: ${{ steps.destination.outputs.owner }}"
 
     - id: destination_dir
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -103,18 +103,12 @@ runs:
         helm-version: v3.10.2
         install-kubectl: false
 
-    #- name: Parse git URL for 
-    #  id: destination
-    #  uses: theowenyoung/git-url-parse@v1
-    #  with:
-    #    url: ${{ inputs.cluster }}
-
-    - name: Install requirements
+    - name: Install git-url-parse
       shell: bash
       run: npm install git-url-parse
 
     - name: Parse git URL for destination
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1, node20
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1, node 20
       id: destination
       with:
         script: |
@@ -136,23 +130,6 @@ runs:
             }
           }
           run("${{ inputs.cluster }}")
-
-    - name: echo output for debugging
-      shell: bash
-      run: |
-        echo "cluster: ${{ inputs.cluster }}"
-        echo "filepath: ${{ steps.destination.outputs.filepath }}"
-        echo "name: ${{ steps.destination.outputs.name }}"
-        echo "ref: ${{ steps.destination.outputs.ref }}"
-        echo "owner: ${{ steps.destination.outputs.owner }}"
-
-        exit 1
-
-    #"cluster: https://github.com/cloudposse/argocd-deploy-non-prod/blob/main/plat/ue2-dev/apps"
-    #"filepath: plat/ue2-dev/apps"
-    #"name: argocd-deploy-non-prod"
-    #"ref: main"
-    #"owner: cloudposse"
 
     - id: destination_dir
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -105,10 +105,10 @@ runs:
 
     - name: Install git-url-parse
       shell: bash
-      run: npm install git-url-parse
+      run: npm install git-url-parse@14.0.0
 
     - name: Parse git URL for destination
-      uses: actions/github-script@v7
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1, node 20
       id: destination
       with:
         script: |

--- a/action.yml
+++ b/action.yml
@@ -109,7 +109,10 @@ runs:
     #  with:
     #    url: ${{ inputs.cluster }}
 
-    - run: npm install git-url-parse
+    - name: Install requirements
+      shell: bash
+      run: npm install git-url-parse
+
     - name: Parse git URL for destination
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1, node20
       id: destination


### PR DESCRIPTION
## what
- Resolving deprecation warning
- Replaced `theowenyoung/git-url-parse` with inline node script

## why
- We were using the https://github.com/theowenyoung/git-url-parse action in our [argocd](https://github.com/cloudposse/github-action-deploy-argocd) reusable action. The upstream action is using node 12 and set-output and hasn't been updated in 3 years. It's throwing warnings every time it runs. We should either fork and update that action or find a replacement.
- This script is fairly simple. It's easy enough to inline the script and not require another repo to maintain

## references
- DEV-1396
- https://github.com/cloudposse/example-app-on-eks-with-argocd/pull/26
- https://github.com/theowenyoung/git-url-parse