### PR TITLE
Fix: Change sync to check argocd deploy repo status

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -326,7 +326,7 @@ runs:
       if: ${{ inputs.synchronously == 'true' && inputs.operation == 'deploy' }}
       with:
         #repository: ${{ inputs.repository }}
-        repository: ${{ steps.destination.outputs.ref }}
+        repository: ${{ steps.destination.outputs.full_name }} # Organization/repo
         sha: ${{ inputs.ref }}
         status: "continuous-delivery/${{ inputs.namespace }}.${{ inputs.application }}"
         expected_state: "success"

--- a/action.yml
+++ b/action.yml
@@ -325,7 +325,8 @@ runs:
     - uses: cloudposse/github-action-wait-commit-status@0.2.0
       if: ${{ inputs.synchronously == 'true' && inputs.operation == 'deploy' }}
       with:
-        repository: ${{ inputs.repository }}
+        #repository: ${{ inputs.repository }}
+        repository: ${{ steps.destination.outputs.ref }}
         sha: ${{ inputs.ref }}
         status: "continuous-delivery/${{ inputs.namespace }}.${{ inputs.application }}"
         expected_state: "success"


### PR DESCRIPTION
## what
- Change repo `cloudposse/github-action-wait-commit-status` to the ArgoCD deployment repo

## why
- The commit status we are checking for sync mode is the commit in the ArgoCD deployment repo, not the application repo

## references
- https://github.com/cloudposse-examples/app-on-eks-with-argocd/pull/28
- closes #44 