### PR TITLE
YQ Improvement: Only one url

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -269,7 +269,7 @@ runs:
       shell: bash
       run: |-
         WEBAPP_URL=$( \
-          yq eval-all '.metadata.annotations["outputs.platform.cloudposse.com/webapp-url"] | select(. != null)' \
+          yq -N eval-all '[.metadata.annotations["outputs.platform.cloudposse.com/webapp-url"] | select(. != null)] | .[0]' \
             ${{ steps.config.outputs.tmp }}/manifests/resources.yaml \
         )
         echo "webapp_url=${WEBAPP_URL}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## what
* yq ea reads multi documents, currently rendering as
    ```
    foo.net
    ---
    foo.com
    ```

This then fails the action.

This update enhances that action to remove the `---` from rendering via `-N`. Furthermore it will only pick the first URL found. 
