### PR TITLE
fix: install chamber directly instead of using a container (bypass Docker Hub rate limits)

### DIFF
--- a/.github/workflows/test-destroy.yml
+++ b/.github/workflows/test-destroy.yml
@@ -123,8 +123,8 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           ## Use localhost to connect localstack because the commands runs not in a container
           AWS_ENDPOINT_OVERRIDE: http://localhost:4566
-          ## Use localstack to connect localstack because the chamber runs in a container
-          CHAMBER_AWS_SSM_ENDPOINT: http://localstack:4566/
+          ## Use localhost to connect localstack because chamber does not run in a container
+          CHAMBER_AWS_SSM_ENDPOINT: http://localhost:4566/
 
     outputs:
       sha: ${{ steps.current.outputs.sha }}

--- a/.github/workflows/test-helm-raw-default-kube-version.yml
+++ b/.github/workflows/test-helm-raw-default-kube-version.yml
@@ -79,8 +79,8 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           ## Use localhost to connect localstack because the commands runs not in a container
           AWS_ENDPOINT_OVERRIDE: http://localhost:4566
-          ## Use localstack to connect localstack because the chamber runs in a container
-          CHAMBER_AWS_SSM_ENDPOINT: http://localstack:4566/
+          ## Use localhost to connect localstack because chamber does not run in a container
+          CHAMBER_AWS_SSM_ENDPOINT: http://localhost:4566/
 
     outputs:
       status: ${{ steps.current.outcome }}

--- a/.github/workflows/test-helm-raw.yml
+++ b/.github/workflows/test-helm-raw.yml
@@ -85,8 +85,8 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           ## Use localhost to connect localstack because the commands runs not in a container
           AWS_ENDPOINT_OVERRIDE: http://localhost:4566
-          ## Use localstack to connect localstack because the chamber runs in a container
-          CHAMBER_AWS_SSM_ENDPOINT: http://localstack:4566/
+          ## Use localhost to connect localstack because chamber does not run in a container
+          CHAMBER_AWS_SSM_ENDPOINT: http://localhost:4566/
 
     outputs:
       status: ${{ steps.current.outcome }}

--- a/.github/workflows/test-helmfile-raw-default-kube-version.yml
+++ b/.github/workflows/test-helmfile-raw-default-kube-version.yml
@@ -82,8 +82,8 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           ## Use localhost to connect localstack because the commands runs not in a container
           AWS_ENDPOINT_OVERRIDE: http://localhost:4566
-          ## Use localstack to connect localstack because the chamber runs in a container
-          CHAMBER_AWS_SSM_ENDPOINT: http://localstack:4566/
+          ## Use localhost to connect localstack because chamber does not run in a container
+          CHAMBER_AWS_SSM_ENDPOINT: http://localhost:4566/
 
     outputs:
       status: ${{ steps.current.outcome }}

--- a/.github/workflows/test-helmfile-raw.yml
+++ b/.github/workflows/test-helmfile-raw.yml
@@ -91,8 +91,8 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           ## Use localhost to connect localstack because the commands runs not in a container
           AWS_ENDPOINT_OVERRIDE: http://localhost:4566
-          ## Use localstack to connect localstack because the chamber runs in a container
-          CHAMBER_AWS_SSM_ENDPOINT: http://localstack:4566/
+          ## Use localhost to connect localstack because chamber does not run in a container
+          CHAMBER_AWS_SSM_ENDPOINT: http://localhost:4566/
 
     outputs:
       status: ${{ steps.current.outcome }}

--- a/action.yml
+++ b/action.yml
@@ -181,8 +181,8 @@ runs:
       run: |
         os=$(echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]')
         arch=$(echo ${{ runner.arch }} | tr '[:upper:]' '[:lower:]')
-        curl -LOs https://github.com/segmentio/chamber/releases/download/${version}/chamber-${version}-${os}-${arch} -o /tmp/chamber
-        install /tmp/chamber /usr/local/bin/chamber
+        curl -LOs https://github.com/segmentio/chamber/releases/download/${version}/chamber-${version}-${os}-${arch}
+        install chamber-${version}-${os}-${arch} /usr/local/bin/chamber
 
     - name: Read platform context
       if: ${{ inputs.operation == 'deploy' }}

--- a/action.yml
+++ b/action.yml
@@ -181,7 +181,22 @@ runs:
       run: |
         set -x
         os=$(uname -s | tr '[:upper:]' '[:lower:]')
-        arch=$(arch)
+        arch=""
+        case $(uname -m) in
+          x86_64)
+            arch="amd64"
+            ;;
+          aarch64)
+            arch="arm64"
+            ;;
+          arch64)
+            arch="arm64"
+            ;;
+          *)
+            echo "Unsupported architecture $(uname -m)"
+            exit 1
+            ;;
+        esac
         curl -LOs https://github.com/segmentio/chamber/releases/download/${version}/chamber-${version}-${os}-${arch}
         install chamber-${version}-${os}-${arch} /usr/local/bin/chamber
 

--- a/action.yml
+++ b/action.yml
@@ -180,8 +180,8 @@ runs:
         version: v2.14.1
       run: |
         set -x
-        os=$(echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]')
-        arch=$(echo ${{ runner.arch }} | tr '[:upper:]' '[:lower:]')
+        os=$(uname -s | tr '[:upper:]' '[:lower:]')
+        arch=$(uname -m | tr '[:upper:]' '[:lower:]')
         curl -LOs https://github.com/segmentio/chamber/releases/download/${version}/chamber-${version}-${os}-${arch}
         install chamber-${version}-${os}-${arch} /usr/local/bin/chamber
 

--- a/action.yml
+++ b/action.yml
@@ -179,6 +179,7 @@ runs:
       env:
         version: v2.14.1
       run: |
+        set -x
         os=$(echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]')
         arch=$(echo ${{ runner.arch }} | tr '[:upper:]' '[:lower:]')
         curl -LOs https://github.com/segmentio/chamber/releases/download/${version}/chamber-${version}-${os}-${arch}

--- a/action.yml
+++ b/action.yml
@@ -181,7 +181,8 @@ runs:
       run: |
         os=$(echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]')
         arch=$(echo ${{ runner.arch }} | tr '[:upper:]' '[:lower:]')
-        curl -LOs https://github.com/segmentio/chamber/releases/download/${version}/chamber-${version}-${os}-${arch}
+        curl -LOs https://github.com/segmentio/chamber/releases/download/${version}/chamber-${version}-${os}-${arch} -o /tmp/chamber
+        install /tmp/chamber /usr/local/bin/chamber
 
     - name: Read platform context
       if: ${{ inputs.operation == 'deploy' }}

--- a/action.yml
+++ b/action.yml
@@ -181,7 +181,7 @@ runs:
       run: |
         set -x
         os=$(uname -s | tr '[:upper:]' '[:lower:]')
-        arch=$(uname -m | tr '[:upper:]' '[:lower:]')
+        arch=$(arch)
         curl -LOs https://github.com/segmentio/chamber/releases/download/${version}/chamber-${version}-${os}-${arch}
         install chamber-${version}-${os}-${arch} /usr/local/bin/chamber
 

--- a/action.yml
+++ b/action.yml
@@ -173,11 +173,21 @@ runs:
         token: ${{ inputs.github-pat }}
         path: ${{ steps.destination_dir.outputs.name }}
 
-    - name: Read platform context
-      uses: docker://segment/chamber:2.14.1
+    - name: Setup chamber
       if: ${{ inputs.operation == 'deploy' }}
-      with:
-        args: --verbose export ${{ inputs.ssm-path }}/${{ inputs.environment }} --format yaml --output-file ./platform.yaml
+      shell: bash
+      env:
+        version: v2.14.1
+      run: |
+        os=$(echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]')
+        arch=$(echo ${{ runner.arch }} | tr '[:upper:]' '[:lower:]')
+        curl -LOs https://github.com/segmentio/chamber/releases/download/${version}/chamber-${version}-${os}-${arch}
+
+    - name: Read platform context
+      if: ${{ inputs.operation == 'deploy' }}
+      shell: bash
+      run: |
+        chamber --verbose export ${{ inputs.ssm-path }}/${{ inputs.environment }} --format yaml --output-file ./platform.yaml
 
     - name: YQ Platform settings
       if: ${{ inputs.operation == 'deploy' }}
@@ -187,10 +197,10 @@ runs:
         yq --exit-status --no-colors --inplace eval '{"platform": .}' ./platform.yaml
 
     - name: Read platform metadata
-      uses: docker://segment/chamber:2.14.1
       if: ${{ inputs.operation == 'deploy' }}
-      with:
-        args: --verbose export ${{ inputs.ssm-path }}/_metadata --format yaml --output-file ./_metadata.yaml
+      shell: bash
+      run: |
+        chamber --verbose export ${{ inputs.ssm-path }}/_metadata --format yaml --output-file ./_metadata.yaml
 
     - name: YQ Platform settings
       if: ${{ inputs.operation == 'deploy' }}


### PR DESCRIPTION
## what
* Install chamber directly instead of using a container
* Update localstack endpoint for chamber, now that chamber does not run in a container.

## why
* Bypass Docker Hub rate limits

## references
* N/A
