### PR TITLE
fix: use 'sudo' when installing the chamber binary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -198,7 +198,7 @@ runs:
             ;;
         esac
         curl -LOs https://github.com/segmentio/chamber/releases/download/${version}/chamber-${version}-${os}-${arch}
-        install chamber-${version}-${os}-${arch} /usr/local/bin/chamber
+        sudo install chamber-${version}-${os}-${arch} /usr/local/bin/chamber
 
     - name: Read platform context
       if: ${{ inputs.operation == 'deploy' }}


### PR DESCRIPTION
## what
* use 'sudo' when installing the chamber binary

## why

The test suite in this repo passed, but using this action in practice results in:

```bash
+ install chamber-v2.14.1-linux-amd64 /usr/local/bin/chamber
install: cannot create regular file '/usr/local/bin/chamber': Permission denied
```

## references
* Follow up for #60 
