### PR TITLE
feat: add support for extra env vars

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,6 +98,10 @@ inputs:
     description: 'Additional helm arguments'
     required: false
     default: ""
+  extra-env-vars:
+    description: 'A JSON string of additional environment variables'
+    required: false
+    default: ""
 outputs:
   webapp-url:
     description: "Web Application url"
@@ -244,6 +248,12 @@ runs:
           false:
             kube_version: --kube-version=${{ steps.metadata.outputs.kube_version }}      
 
+    - name: Extra env vars
+      if: ${{ inputs.extra-env-vars != '' }}
+      shell: bash
+      run: |
+        echo '${{ inputs.extra-env-vars }}' > env.json
+        cat env.json | jq -r 'to_entries | .[] | "\(.key)=\(.value)"' >> $GITHUB_ENV
 
     - name: Ensure argocd repo structure
       if: ${{ inputs.operation == 'deploy' }}

--- a/action.yml
+++ b/action.yml
@@ -253,6 +253,9 @@ runs:
       shell: bash
       run: |
         echo '${{ inputs.extra-env-vars }}' > env.json
+        for var in $(jq -r 'keys[]' env.json); do
+          echo "::add-mask::$(jq -r --arg v "$var" '.[$v]' env.json)"
+        done
         cat env.json | jq -r 'to_entries | .[] | "\(.key)=\(.value)"' >> $GITHUB_ENV
 
     - name: Ensure argocd repo structure


### PR DESCRIPTION
## what
* Adds support for extra environment variables

## why
* Private Helmfile chart repositories require a username and password in a specific format or supplied through the `username` and `password: args on the repo itself. When those values are not available to change to the proper format, they need to be supplied through custom env vars.

```
repositories:
  - name: artifactory
    url: my.jfrog.io
    oci: true
    username: '{{ env "ARTIFACTORY_USER" }}'
    password: '{{ env "ARTIFACTORY_PASS" }}'
```

The expected format would be `ARTIFACTORY_USERNAME` and `ARTIFACTORY_PASSWORD`, but those are not capable of being changed without legacy concerns.

## references