### PR TITLE
feat: Support alternate token for sync mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,8 +67,8 @@ inputs:
   github-pat:
     description: Github PAT to access argocd configuration repository
     required: true
-  commit-status-github-pat:
-    description: Github PAT to access the app repository. Defaults to github-pat if not set.
+  commit-status-github-token:
+    description: Github token to access the app repository. Defaults to github-pat if not set.
     required: false
   synchronously:
     description: "Wait until ArgoCD successfully apply the changes"
@@ -390,10 +390,10 @@ runs:
       id: commit_status_github_token
       if: ${{ inputs.synchronously == 'true' && inputs.operation == 'deploy' }}
       command: |
-        if [ -z "${{ inputs.commit-status-github-pat }}" ]; then
+        if [ -z "${{ inputs.commit-status-github-token }}" ]; then
           echo "token=${{ inputs.github-pat }}" >> $GITHUB_OUTPUT
         else
-          echo "token=${{ inputs.commit-status-github-pat }}" >> $GITHUB_OUTPUT
+          echo "token=${{ inputs.commit-status-github-token }}" >> $GITHUB_OUTPUT
         fi
 
     - uses: cloudposse/github-action-wait-commit-status@0.2.0

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,9 @@ inputs:
   github-pat:
     description: Github PAT to access argocd configuration repository
     required: true
+  commit-status-github-pat:
+    description: Github PAT to access the app repository. Defaults to github-pat if not set.
+    required: false
   synchronously:
     description: "Wait until ArgoCD successfully apply the changes"
     default: 'false'
@@ -382,6 +385,17 @@ runs:
           
           popd
 
+    - name: Select GitHub Token for Sync Mode
+      shell: bash
+      id: commit_status_github_token
+      if: ${{ inputs.synchronously == 'true' && inputs.operation == 'deploy' }}
+      command: |
+        if [ -z "${{ inputs.commit-status-github-pat }}" ]; then
+          echo "token=${{ inputs.github-pat }}" >> $GITHUB_OUTPUT
+        else
+          echo "token=${{ inputs.commit-status-github-pat }}" >> $GITHUB_OUTPUT
+        fi
+
     - uses: cloudposse/github-action-wait-commit-status@0.2.0
       if: ${{ inputs.synchronously == 'true' && inputs.operation == 'deploy' }}
       with:
@@ -389,6 +403,6 @@ runs:
         sha: ${{ inputs.ref }}
         status: "continuous-delivery/${{ inputs.namespace }}.${{ inputs.application }}"
         expected_state: "success"
-        token: ${{ inputs.github-pat }}
+        token: ${{ steps.commit_status_github_token.outputs.token }}
         check-retry-count: ${{ inputs.check-retry-count }}
         check-retry-interval: ${{ inputs.check-retry-interval }}      

--- a/action.yml
+++ b/action.yml
@@ -386,10 +386,10 @@ runs:
           popd
 
     - name: Select GitHub Token for Sync Mode
-      shell: bash
       id: commit_status_github_token
       if: ${{ inputs.synchronously == 'true' && inputs.operation == 'deploy' }}
-      command: |
+      shell: bash
+      run: |-
         if [ -z "${{ inputs.commit-status-github-token }}" ]; then
           echo "token=${{ inputs.github-pat }}" >> $GITHUB_OUTPUT
         else


### PR DESCRIPTION
## what
- Add option to specify a different token for sync mode

## why
- We need permission to 2 different repo: the desire state repo (to update manifests) and the app repo (to send sync mode updates)

## references
- n/a
