### PR TITLE
DEV-2256 Fix helmfile install

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @SmithHealth/devops

--- a/action.yml
+++ b/action.yml
@@ -131,12 +131,13 @@ runs:
         force: true
 
     - name: Setup helmfile
-      uses: mamezou-tech/setup-helmfile@v1.2.0
+      uses: mamezou-tech/setup-helmfile@v2.1.0
       if: ${{ inputs.operation == 'deploy' }}
       with:
         helmfile-version: "${{ inputs.helmfile-version }}"
         helm-version: "${{ inputs.helm-version }}"
         install-kubectl: false
+        install-helm-plugins: false
 
     - name: Setup node
       uses: actions/setup-node@v4


### PR DESCRIPTION
## what
* Skips `helm` plugin installs

## why
* Helm plugin installs tends to cause errors for us. They shouldn't be needed

## references
* git checkout -b DEV-2256-setup-helmfile-github-action-error
* https://github.com/mamezou-tech/setup-helmfile
