### PR TITLE
Make ssm-path optional and add kube-version input to skip AWS SSM look up

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -240,7 +240,8 @@ runs:
     - name: Create empty platform context
       if: ${{ inputs.operation == 'deploy' && inputs.ssm-path == '' }}
       shell: bash
-      run: echo 'platform: {}' > ./platform.yaml
+      run: |
+        echo 'platform: {}' > ./platform.yaml
 
     - name: Read platform metadata
       if: ${{ inputs.operation == 'deploy' && inputs.ssm-path != '' }}

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,8 @@ inputs:
     required: false
     default: helmfile
   ssm-path:
-    required: true
+    required: false
+    default: ''
     description: SSM path to read environment secrets
   operation:
     description: Operation with helmfiles. (valid options - `deploy`, `destroy`)
@@ -112,7 +113,11 @@ inputs:
   helmfile-version:
     description: "Helmfile version"
     required: false
-    default: "v0.148.1"    
+    default: "v0.148.1"
+  kube-version:
+    description: "Kubernetes version for helm/helmfile rendering (e.g. `1.28`). When provided, skips SSM metadata lookup via chamber."
+    required: false
+    default: ""    
 outputs:
   webapp-url:
     description: "Web Application url"
@@ -193,7 +198,7 @@ runs:
         path: ${{ steps.destination_dir.outputs.name }}
 
     - name: Setup chamber
-      if: ${{ inputs.operation == 'deploy' }}
+      if: ${{ inputs.operation == 'deploy' && inputs.ssm-path != '' }}
       shell: bash
       env:
         version: v2.14.1
@@ -220,26 +225,31 @@ runs:
         sudo install chamber-${version}-${os}-${arch} /usr/local/bin/chamber
 
     - name: Read platform context
-      if: ${{ inputs.operation == 'deploy' }}
+      if: ${{ inputs.operation == 'deploy' && inputs.ssm-path != '' }}
       shell: bash
       run: |
         chamber --verbose export ${{ inputs.ssm-path }}/${{ inputs.environment }} --format yaml --output-file ./platform.yaml
 
     - name: YQ Platform settings
-      if: ${{ inputs.operation == 'deploy' }}
+      if: ${{ inputs.operation == 'deploy' && inputs.ssm-path != '' }}
       shell: bash
       run: |
         sudo chmod 777 ./platform.yaml 
         yq --exit-status --no-colors --inplace eval '{"platform": .}' ./platform.yaml
 
+    - name: Create empty platform context
+      if: ${{ inputs.operation == 'deploy' && inputs.ssm-path == '' }}
+      shell: bash
+      run: echo 'platform: {}' > ./platform.yaml
+
     - name: Read platform metadata
-      if: ${{ inputs.operation == 'deploy' }}
+      if: ${{ inputs.operation == 'deploy' && inputs.ssm-path != '' }}
       shell: bash
       run: |
         chamber --verbose export ${{ inputs.ssm-path }}/_metadata --format yaml --output-file ./_metadata.yaml
 
     - name: YQ Platform settings
-      if: ${{ inputs.operation == 'deploy' }}
+      if: ${{ inputs.operation == 'deploy' && inputs.ssm-path != '' }}
       shell: bash
       id: metadata
       run: |
@@ -247,17 +257,28 @@ runs:
           echo "${output}" >> $GITHUB_OUTPUT ;
         done
 
+    - name: Resolve kube version
+      id: resolved_kube_version
+      if: ${{ inputs.operation == 'deploy' }}
+      shell: bash
+      run: |
+        kube_version="${{ inputs.kube-version }}"
+        if [ -z "$kube_version" ] && [ -n "${{ inputs.ssm-path }}" ]; then
+          kube_version="${{ steps.metadata.outputs.kube_version }}"
+        fi
+        echo "value=$kube_version" >> $GITHUB_OUTPUT
+
     - name: Context
       if: ${{ inputs.operation == 'deploy' }}
       id: arguments
       uses: cloudposse/github-action-yaml-config-query@0.1.3
       with:
-        query: .${{ steps.metadata.outputs.kube_version == '' }}
+        query: .${{ steps.resolved_kube_version.outputs.value == '' }}
         config: |-
           true: 
             kube_version: ""
           false:
-            kube_version: --kube-version=${{ steps.metadata.outputs.kube_version }}      
+            kube_version: --kube-version=${{ steps.resolved_kube_version.outputs.value }}      
 
 
     - name: Ensure argocd repo structure


### PR DESCRIPTION
## what
* Make ssm-path optional
* Add kube-version input

## why
* Allows us to skip AWS SSM look up via chamber to simplify/speed up deploys
* The EKS quickstart from Cloudposse no longer includes the `eks/platform` component which was responsible for setting the SSM parameter for the cluster with the `kube_version`, but this action still tries to look up the SSM param on every deploy

## references

